### PR TITLE
Export interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ project(spirv2clc)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(GenerateExportHeader)
+
 set(SPIRV-Headers_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/SPIRV-Headers)
 set(SPIRV_TOOLS_DIR ${PROJECT_SOURCE_DIR}/external/SPIRV-Tools)
 set(SPIRV_TOOLS_BINARY_DIR ${CMAKE_BINARY_DIR}/external/SPIRV-Tools)

--- a/include/spirv2clc.h
+++ b/include/spirv2clc.h
@@ -21,15 +21,19 @@
 #include <vector>
 
 #include "opt/ir_context.h"
+#include <libspirv2clc_export.h>
 
 namespace spirv2clc {
 
 struct translator {
 
-  translator(spv_target_env env = SPV_ENV_OPENCL_1_2) : m_target_env(env) {}
+  LIBSPIRV2CLC_EXPORT translator(spv_target_env env = SPV_ENV_OPENCL_1_2)
+      : m_target_env(env) {}
 
-  int translate(const std::string &assembly, std::string *srcout);
-  int translate(const std::vector<uint32_t> &binary, std::string *srcout);
+  LIBSPIRV2CLC_EXPORT int translate(const std::string &assembly,
+                                    std::string *srcout);
+  LIBSPIRV2CLC_EXPORT int translate(const std::vector<uint32_t> &binary,
+                                    std::string *srcout);
 
 private:
   uint32_t type_id_for(uint32_t val) const {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,9 +16,17 @@ add_library(libspirv2clc translator.cpp)
 
 target_include_directories(libspirv2clc PUBLIC
     ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR} # For the export header
     ${OPENCL_HEADERS_DIR}
     ${SPIRV_TOOLS_DIR}
     ${SPIRV_TOOLS_DIR}/source
     ${SPIRV_TOOLS_BINARY_DIR})
 
+set_target_properties(libspirv2clc PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+
 target_link_libraries(libspirv2clc SPIRV-Tools-opt)
+
+generate_export_header(libspirv2clc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(testlayer)
+if(NOT WIN32)
+  # testlayer doesn't work on Windows
+  add_subdirectory(testlayer)
+endif()


### PR DESCRIPTION
1. Export the minimal publicly available interface
    * Instead of exporting all symbols
    * Only constructor and `translate` functions
2. Set visibility to hidden to mimic default Windows behavior
3. These fixes enable Windows support for shared libraries,
  but `testlayer` still won't work, disable it on Windows

This is the first patch targeting https://github.com/kpet/spirv2clc/issues/6.