### PR TITLE
Don't include impl headers

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,9 +14,11 @@
 
 add_library(libspirv2clc translator.cpp)
 
-target_include_directories(libspirv2clc PUBLIC
+target_include_directories(libspirv2clc
+  PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR} # For the export header
+  PRIVATE
     ${OPENCL_HEADERS_DIR}
     ${SPIRV_TOOLS_DIR}
     ${SPIRV_TOOLS_DIR}/source

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,6 +14,4 @@
 
 add_executable(spirv2clc spirv2clc.cpp)
 
-target_include_directories(spirv2clc PRIVATE
-    ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(spirv2clc libspirv2clc)

--- a/tools/spirv2clc.cpp
+++ b/tools/spirv2clc.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
This patch reduces the number of headers included from the main `spirv2clc.h` header,
namely it removes implementation headers from the SPIR-V dependencies.
Those headers are instead included in `translator.cpp`
so that they're no longer visible in the public interface.

The main header still needs to include some headers from the SPIR-V dependencies,
and forward declares some of the implementation types.
A lot of code has been moved in the `.cpp` file, without functional changes.

Because the translator now contains a `unique_ptr` to an incomplete type (`spvtools::opt::IRContext`),
all special member functions had to be exported as well,
with their definitions moved to the `.cpp` file.

CMake has also been adjusted since it's no longer necessary
to add include paths to SPIR-V dependencies headers.

Second patch for https://github.com/kpet/spirv2clc/issues/6.