### PR TITLE
[CMake] Install library

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ std::vector<uint32_t> binary;
 int err = translator.translate(binary, &srcgen);
 ```
 
+## Installation
+
+To install the library, first check you're building with the right CMake variables set:
+* `CMAKE_INSTALL_PREFIX` - Location of the final package.
+* `BUILD_SHARED_LIBS` - Whether to build spirv2clc as a shared library or a static library.
+  Note that a static library build at the moment requires the user
+  to manually provide the SPIR-V dependencies as static libraries
+  in the target project (where you want to embed spirv2clc).
+* `CMAKE_POSITION_INDEPENDENT_CODE` - Whether to enable `fPIC` or similar flags
+  when building the library. Ensure this matches the target project.
+
+To install the library after a successful build, run the following command:
+```sh
+cmake --install .
+```
+
+After the installation step you can use spirv2clc as an `IMPORTED` library
+in your target project.
+
 # Running with test layer
 
 A layer that enables a round-trip translation of OpenCL C programs to SPIR-V and

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,3 +32,27 @@ set_target_properties(libspirv2clc PROPERTIES
 target_link_libraries(libspirv2clc SPIRV-Tools-opt)
 
 generate_export_header(libspirv2clc)
+
+install(TARGETS libspirv2clc
+    RUNTIME DESTINATION lib COMPONENT libraries
+    LIBRARY DESTINATION lib COMPONENT libraries
+    ARCHIVE DESTINATION lib COMPONENT libraries
+)
+install(FILES
+        "${PROJECT_SOURCE_DIR}/include/spirv2clc.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/libspirv2clc_export.h"
+    DESTINATION include
+    COMPONENT headers
+)
+install(DIRECTORY "${SPIRV_TOOLS_DIR}/include"
+    DESTINATION .
+    COMPONENT headers
+    FILES_MATCHING
+        PATTERN "spirv-tools/libspirv.h"
+)
+install(DIRECTORY "${SPIRV-Headers_SOURCE_DIR}/include"
+    DESTINATION .
+    COMPONENT headers
+    FILES_MATCHING
+        PATTERN "spirv/unified1/spirv.h"
+)


### PR DESCRIPTION
Install the library and the headers it depends on.
Works with a shared library build (`BUILD_SHARED_LIBS=ON`).

In theory it works with a static library build as well,
but the installation step would have to include the SPIR-V dependencies as static libraries,
which this patch doesn't address.

Provided some installation info.

---

Example install folder:
```
> tree package/
package/
├── include
│   ├── libspirv2clc_export.h
│   ├── spirv
│   │   ├── 1.0
│   │   ├── 1.1
│   │   ├── 1.2
│   │   └── unified1
│   │       └── spirv.h
│   ├── spirv-tools
│   │   └── libspirv.h
│   └── spirv2clc.h
└── lib
    └── liblibspirv2clc.so
```

I wasn't sure how to get rid of the empty folders, but I figured there's no harm in keeping them.

Also note that this doesn't do a "proper" CMake installation, which would require exporting the targets and creating a config file, but it's the first step to making spirv2clc much easier to set up in external projects.