### PR TITLE
Layer MVP

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,10 +35,10 @@ generate_export_header(libspirv2clc)
 
 add_library(SPIRV2CLC-Layer SHARED layer.cpp)
 
-target_link_libraries(SPIRV2CLC-Layer PUBLIC libspirv2clc)
-
 target_compile_features(SPIRV2CLC-Layer PUBLIC cxx_std_17)
 
 target_compile_definitions(SPIRV2CLC-Layer
   PUBLIC
     CL_TARGET_OPENCL_VERSION=300)
+
+target_link_libraries(SPIRV2CLC-Layer PUBLIC libspirv2clc)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,3 +32,9 @@ set_target_properties(libspirv2clc PROPERTIES
 target_link_libraries(libspirv2clc SPIRV-Tools-opt)
 
 generate_export_header(libspirv2clc)
+
+add_library(SPIRV2CLC-Layer SHARED layer.cpp)
+
+target_link_libraries(SPIRV2CLC-Layer PUBLIC libspirv2clc)
+
+target_compile_features(SPIRV2CLC-Layer PUBLIC cxx_std_17)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,6 +35,10 @@ generate_export_header(libspirv2clc)
 
 add_library(SPIRV2CLC-Layer SHARED layer.cpp)
 
+target_include_directories(SPIRV2CLC-Layer
+  PRIVATE
+    ${OPENCL_HEADERS_DIR})
+
 target_compile_features(SPIRV2CLC-Layer PUBLIC cxx_std_17)
 
 target_compile_definitions(SPIRV2CLC-Layer

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,3 +38,7 @@ add_library(SPIRV2CLC-Layer SHARED layer.cpp)
 target_link_libraries(SPIRV2CLC-Layer PUBLIC libspirv2clc)
 
 target_compile_features(SPIRV2CLC-Layer PUBLIC cxx_std_17)
+
+target_compile_definitions(SPIRV2CLC-Layer
+  PUBLIC
+    CL_TARGET_OPENCL_VERSION=300)

--- a/lib/layer.cpp
+++ b/lib/layer.cpp
@@ -1,0 +1,249 @@
+#include "spirv2clc.h"
+
+#include <CL/cl_layer.h>
+
+#include <vector>
+#include <string_view>
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+
+static struct _cl_icd_dispatch dispatch = {};
+
+static const struct _cl_icd_dispatch *tdispatch;
+
+  /* Layer API entry points */
+CL_API_ENTRY cl_int CL_API_CALL
+clGetLayerInfo(
+    cl_layer_info  param_name,
+    size_t         param_value_size,
+    void          *param_value,
+    size_t        *param_value_size_ret) {
+  switch (param_name) {
+  case CL_LAYER_API_VERSION:
+    if (param_value) {
+      if (param_value_size < sizeof(cl_layer_api_version))
+        return CL_INVALID_VALUE;
+      *((cl_layer_api_version *)param_value) = CL_LAYER_API_VERSION_100;
+    }
+    if (param_value_size_ret)
+      *param_value_size_ret = sizeof(cl_layer_api_version);
+    break;
+  default:
+    return CL_INVALID_VALUE;
+  }
+  return CL_SUCCESS;
+}
+
+static void _init_dispatch(void);
+
+CL_API_ENTRY cl_int CL_API_CALL
+clInitLayer(
+    cl_uint                         num_entries,
+    const struct _cl_icd_dispatch  *target_dispatch,
+    cl_uint                        *num_entries_out,
+    const struct _cl_icd_dispatch **layer_dispatch_ret) {
+  if (!target_dispatch || !layer_dispatch_ret ||!num_entries_out || num_entries < sizeof(dispatch)/sizeof(dispatch.clGetPlatformIDs))
+    return CL_INVALID_VALUE;
+
+  tdispatch = target_dispatch;
+  _init_dispatch();
+
+  *layer_dispatch_ret = &dispatch;
+  *num_entries_out = sizeof(dispatch)/sizeof(dispatch.clGetPlatformIDs);
+  return CL_SUCCESS;
+}
+
+// Layer logic
+
+inline cl_int clGetDeviceInfo_CL_DEVICE_EXTENSIONS(
+  cl_device_id device,
+  cl_device_info param_name,
+  size_t param_value_size,
+  void* param_value,
+  size_t* param_value_size_ret)
+{
+  // If querying extensions, check if SPIR-V is supported
+  size_t dispatch_param_value_size_ret = 0;
+  cl_int err_ = tdispatch->clGetDeviceInfo(
+    device,
+    CL_DEVICE_EXTENSIONS,
+    0,
+    nullptr,
+    &dispatch_param_value_size_ret);
+  if (err_ == CL_SUCCESS)
+  {
+    std::vector<char> dispatch_extensions(
+      dispatch_param_value_size_ret,
+      '\0'
+    );
+    err_ = tdispatch->clGetDeviceInfo(
+      device,
+      CL_DEVICE_EXTENSIONS,
+      dispatch_extensions.size(),
+      dispatch_extensions.data(),
+      nullptr
+    );
+    std::string_view dispatch_extensions_string{
+      dispatch_extensions.data(),
+      dispatch_extensions.size()
+    };
+    #define spirv_ext_name "cl_khr_il_program"
+    if (dispatch_extensions_string.find(spirv_ext_name) != std::string::npos)
+    {
+      // If SPIR-V is supported, pass along invocation unchanged
+      return tdispatch->clGetDeviceInfo(
+        device,
+        CL_DEVICE_EXTENSIONS,
+        param_value_size,
+        param_value,
+        param_value_size_ret);
+    }
+    else
+    {
+      // If not supported, layer has to append to supported extensions
+      size_t layer_param_value_size_ret =
+        dispatch_param_value_size_ret +
+        1 + // space
+        sizeof(spirv_ext_name);
+      if (param_value_size_ret != nullptr)
+        *param_value_size_ret = layer_param_value_size_ret;
+      std::stringstream layer_extensions_stream;
+      layer_extensions_stream <<
+        dispatch_extensions_string <<
+        " " <<
+        spirv_ext_name;
+      if (param_value_size >= layer_param_value_size_ret)
+      {
+        if (param_value != nullptr)
+        {
+          std::copy(
+            std::istreambuf_iterator<char>{layer_extensions_stream},
+            std::istreambuf_iterator<char>{},
+            static_cast<char*>(param_value)
+          );
+          return CL_SUCCESS;
+        }
+        else
+          return CL_INVALID_VALUE;
+      }
+      else
+        return CL_INVALID_VALUE;
+    }
+    #undef spirv_ext_name
+  }
+  else
+    return err_;
+}
+
+inline cl_int clGetDeviceInfo_CL_DEVICE_IL_VERSION(
+    cl_device_id device,
+    cl_device_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+  // TODO: check platform version of device if the query is
+  //       available to begin with
+  return CL_SUCCESS;
+}
+
+static CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfo_wrap(
+    cl_device_id device,
+    cl_device_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)
+{
+  switch (param_name)
+  {
+    case CL_DEVICE_EXTENSIONS:
+      clGetDeviceInfo_CL_DEVICE_EXTENSIONS(
+        device,
+        param_name,
+        param_value_size,
+        param_value,
+        param_value_size_ret
+      );
+      break;
+    case CL_DEVICE_IL_VERSION:
+      clGetDeviceInfo_CL_DEVICE_IL_VERSION(
+        device,
+        param_name,
+        param_value_size,
+        param_value,
+        param_value_size_ret
+      );
+      break;
+    default:
+      return tdispatch->clGetDeviceInfo(
+        device,
+        param_name,
+        param_value_size,
+        param_value,
+        param_value_size_ret);
+      break;
+  }
+}
+
+static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithIL_wrap(
+    cl_context context,
+    const void* il,
+    size_t length,
+    cl_int* errcode_ret)
+{
+  cl_program program = tdispatch->clCreateProgramWithIL(
+    context,
+    il,
+    length,
+    errcode_ret);
+  return program;
+}
+
+static CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithBinary_wrap(
+    cl_context context,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const size_t* lengths,
+    const unsigned char** binaries,
+    cl_int* binary_status,
+    cl_int* errcode_ret)
+{
+  spirv2clc::translator translator;
+  std::string srcgen;
+  std::vector<uint32_t> binary;
+
+  int err = translator.translate(binary, &srcgen);
+  cl_program program = tdispatch->clCreateProgramWithBinary(
+    context,
+    num_devices,
+    device_list,
+    lengths,
+    binaries,
+    binary_status,
+    errcode_ret);
+  return program;
+}
+
+static CL_API_ENTRY cl_int CL_API_CALL clBuildProgram_wrap(
+    cl_program program,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    const char* options,
+    void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+    void* user_data)
+{
+  return tdispatch->clBuildProgram(
+            program,
+            num_devices,
+            device_list,
+            options,
+            pfn_notify,
+            user_data);
+}
+
+static void _init_dispatch(void) {
+  dispatch.clGetDeviceInfo = &clGetDeviceInfo_wrap;
+  dispatch.clCreateProgramWithBinary = &clCreateProgramWithBinary_wrap;
+  dispatch.clBuildProgram = &clBuildProgram_wrap;
+}

--- a/lib/layer.hpp
+++ b/lib/layer.hpp
@@ -41,6 +41,13 @@ CL_API_ENTRY cl_int CL_API_CALL clBuildProgram_wrap(
   void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
   void* user_data);
 
+CL_API_ENTRY cl_int CL_API_CALL clGetProgramInfo_wrap(
+  cl_program program,
+  cl_program_info param_name,
+  size_t param_value_size,
+  void* param_value,
+  size_t* param_value_size_ret);
+
 #include <map>
 #include <memory>
 #include <string>
@@ -83,7 +90,14 @@ namespace spirv2clc
       void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
       void* user_data);
 
-    std::map<cl_program, std::string> program_ils;
+    cl_int clGetProgramInfo(
+      cl_program program,
+      cl_program_info param_name,
+      size_t param_value_size,
+      void* param_value,
+      size_t* param_value_size_ret);
+
+    std::map<cl_program, std::pair<std::string, std::string>> program_ils;
 
   private:
     void init_dispatch(void);
@@ -121,6 +135,13 @@ namespace spirv2clc
     cl_int clGetDeviceInfo_CL_DEVICE_ILS_WITH_VERSION(
       cl_device_id device,
       cl_device_info param_name,
+      size_t param_value_size,
+      void* param_value,
+      size_t* param_value_size_ret);
+
+    cl_int clGetProgramInfo_CL_PROGRAM_IL(
+      cl_program program,
+      cl_program_info param_name,
       size_t param_value_size,
       void* param_value,
       size_t* param_value_size_ret);

--- a/lib/layer.hpp
+++ b/lib/layer.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#if defined(_WIN32)
+#define NOMINMAX
+#endif
+
+#include <CL/cl_layer.h>
+
+CL_API_ENTRY cl_int CL_API_CALL
+clGetLayerInfo(
+  cl_layer_info param_name,
+  size_t        param_value_size,
+  void*         param_value,
+  size_t*       param_value_size_ret);
+
+CL_API_ENTRY cl_int CL_API_CALL
+clInitLayer(
+  cl_uint                  num_entries,
+  const _cl_icd_dispatch*  target_dispatch,
+  cl_uint*                 num_entries_out,
+  const _cl_icd_dispatch** layer_dispatch_ret);
+
+CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfo_wrap(
+  cl_device_id device,
+  cl_device_info param_name,
+  size_t param_value_size,
+  void* param_value,
+  size_t* param_value_size_ret);
+
+CL_API_ENTRY cl_program CL_API_CALL clCreateProgramWithIL_wrap(
+  cl_context context,
+  const void* il,
+  size_t length,
+  cl_int* errcode_ret);
+
+CL_API_ENTRY cl_int CL_API_CALL clBuildProgram_wrap(
+  cl_program program,
+  cl_uint num_devices,
+  const cl_device_id* device_list,
+  const char* options,
+  void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+  void* user_data);
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace spirv2clc
+{
+  class layer
+  {
+  public:
+    layer(const _cl_icd_dispatch* target_dispatch) noexcept;
+
+    layer() = delete;
+    layer(const layer&) = delete;
+    layer(layer&&) = delete;
+    ~layer() = default;
+    layer& operator=(const layer&) = delete;
+    layer& operator=(layer&&) = delete;
+
+    const _cl_icd_dispatch& get_dispatch() const;
+    const _cl_icd_dispatch& get_target_dispatch() const;
+
+    cl_int clGetDeviceInfo(
+      cl_device_id device,
+      cl_device_info param_name,
+      size_t param_value_size,
+      void* param_value,
+      size_t* param_value_size_ret);
+
+    cl_program clCreateProgramWithIL(
+      cl_context context,
+      const void* il,
+      size_t length,
+      cl_int* errcode_ret);
+
+    cl_int clBuildProgram(
+      cl_program program,
+      cl_uint num_devices,
+      const cl_device_id* device_list,
+      const char* options,
+      void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+      void* user_data);
+
+    std::map<cl_program, std::string> program_ils;
+
+  private:
+    void init_dispatch(void);
+
+    bool device_supports_spirv_via_extension(
+      cl_device_id device,
+      cl_int* err);
+
+    bool spirv_queries_are_core_for_device(
+      cl_device_id device,
+      cl_int* err);
+
+    bool spirv_queries_are_valid_for_device(
+      cl_device_id device,
+      cl_int* err);
+
+    bool device_supports_spirv_out_of_the_box(
+      cl_device_id device,
+      cl_int* err);
+
+    cl_int clGetDeviceInfo_CL_DEVICE_EXTENSIONS(
+      cl_device_id device,
+      cl_device_info param_name,
+      size_t param_value_size,
+      void* param_value,
+      size_t* param_value_size_ret);
+
+    cl_int clGetDeviceInfo_CL_DEVICE_IL_VERSION(
+      cl_device_id device,
+      cl_device_info param_name,
+      size_t param_value_size,
+      void* param_value,
+      size_t* param_value_size_ret);
+
+    cl_int clGetDeviceInfo_CL_DEVICE_ILS_WITH_VERSION(
+      cl_device_id device,
+      cl_device_info param_name,
+      size_t param_value_size,
+      void* param_value,
+      size_t* param_value_size_ret);
+
+    const _cl_icd_dispatch* tdispatch;
+    _cl_icd_dispatch dispatch;
+  };
+
+  inline std::unique_ptr<layer> instance;
+}


### PR DESCRIPTION
This is an MVP of a layer wrapping the translator library. Some of the features:

- The layer is written such that it should function using 1.x, 2.y and 3.0 runtimes as well.
- It checks whether API queries are supported either being core for the version of the ICD at hand, or whether they are supported due to supporting the `cl_khr_il_program` extension.
- The layer only alters the behavior of the base ICD when it detects the SPIR-V type ILs are not supported.
  - In such cases, if the layer intercepts compilation but fails to translate, it relays it to the next layer assuming it's a different IL which the ICD likely knows how to handle.

I don't have proper tests in place, but it seems to function fine atop AMD's, Microsoft's and Intel's CPU runtime. Tested on Windows.